### PR TITLE
CDN for mixpanel

### DIFF
--- a/views/includes/mixpanel.ejs
+++ b/views/includes/mixpanel.ejs
@@ -2,7 +2,7 @@
 <script type="text/javascript">
 (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
     b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
-    '//api.mixpanel.com/site_media/js/api/mixpanel.2.js';d=c.getElementsByTagName("script")[0];
+    '//cdn.mxpnl.com/libs/mixpanel-2.0.min.js';d=c.getElementsByTagName("script")[0];
     d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
     var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
     Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:


### PR DESCRIPTION
Mixpanel now suggests using a CDN for delivery of their js files.
