### PR TITLE
Mixpanel backbone

### DIFF
--- a/controllers/schedule.js
+++ b/controllers/schedule.js
@@ -37,7 +37,7 @@ exports = module.exports = function(app){
       , created:0
       , modified:0
       }).populate('currentTerm').exec(function(err, schools){
-        res.render('schedule/schedule', {schools: schools, school: req.school||false, layout: 'app-layout.ejs', built: built});
+        res.render('schedule/schedule', {schools: schools, school: req.school||false, settings: flipflop.evaluateAll(req), layout: 'app-layout.ejs', built: built});
     })
   })
 

--- a/controllers/search.js
+++ b/controllers/search.js
@@ -30,7 +30,19 @@ exports = module.exports = function(app){
 
 
 	app.get('/search', requireSchool, function(req, res){
-		var school = req.school._id||req.school
+		process.hrtime = process.hrtime || function(d){
+			var _now = Date.now()
+				,	now = [Math.floor(_now/1000), Math.floor((_now/1000%1)*1e9)]
+			if ( !d ){
+				return _now
+			}else{
+				diff = _now-d;
+				return [Math.floor(diff/1000), Math.floor((diff/1000%1)*1e9)]
+			}
+		}
+		var _process = process
+			,	startTime = _process.hrtime()
+			,	school = req.school._id||req.school
 			,	query = {query:{school:school}, string: req.query.q}
 			,	EventEmitter = require("events").EventEmitter
 			,	emitter = new EventEmitter()
@@ -71,6 +83,8 @@ exports = module.exports = function(app){
 		// When done, send over the results
 		emitter.on('-', function(){
 			if ( --emitter.toDo === 0){
+				totalTime = _process.hrtime(startTime);
+				searchResults['time'] = totalTime[0]+(totalTime[1]/1e9)
 				res.json(searchResults);
 			}
 		});

--- a/public/scripts/backbone-schedule/app.coffee
+++ b/public/scripts/backbone-schedule/app.coffee
@@ -48,11 +48,11 @@ define(['jQuery'
               , "school": user.get('school')?.id or user.get('school') or @.school?.id
               , "referrer": document.referrer
             mixpanel.name_tag user.get('email') or user.get('name') or user.id
-            mixpanel.track 'authenticated', @.config.tempAdd()
+            mixpanel.track 'authenticated', @.config.asObject()
       @.session.on 'unauthenticated', () =>
         @.friendsList.reset()
         @.friendsList.trigger('unfetched')
-        mixpanel.track 'unauthenticated', @.config.tempAdd()
+        mixpanel.track 'unauthenticated', @.config.asObject()
 
       @.schools = new Schools(CS.schools)
       @.school = new School

--- a/public/scripts/backbone-schedule/app.coffee
+++ b/public/scripts/backbone-schedule/app.coffee
@@ -32,9 +32,25 @@ define(['jQuery'
             @.friendsList.trigger('fetched')
         if @.school != @.session.get('user').get('school')
           @setSchool @.session.get('user').get('school')
+
+        # Mixpanel tracking id user
+        if mixpanel
+          user = @.session.get 'user'
+          mixpanel.identify user.id
+          mixpanel.register
+              "$email": user.get('email')
+            , "$first_name": user.get('firstName')
+            , "$last_name": user.get('lastName')
+            , "$last_login": new Date()
+            , "school": user.get('school')?.id or user.get('school') or @.school?.id
+            , "referrer": document.referrer
+
+          mixpanel.name_tag user.get('email') or user.get('name') or user.id
+          mixpanel.track 'authenticated'
       @.session.on 'unauthenticated', () =>
         @.friendsList.reset()
         @.friendsList.trigger('unfetched')
+        mixpanel.track 'unauthenticated'
 
       @.schools = new Schools(CS.schools)
       @.school = new School

--- a/public/scripts/backbone-schedule/models/filters/time-filter.coffee
+++ b/public/scripts/backbone-schedule/models/filters/time-filter.coffee
@@ -64,6 +64,7 @@ define(['jQuery'
 			toMinutes = (time) ->
 				time.getHours()*60+time.getMinutes()+(time.getSeconds()/60.0)
 
+			return if not section.get 'timeslots'
 			# Loops though all timeslots -> day arrays -> days, adding them to the allDays array
 			for timeslot in section.get 'timeslots'
 				do (timeslot) =>

--- a/public/scripts/backbone-schedule/models/search-results.coffee
+++ b/public/scripts/backbone-schedule/models/search-results.coffee
@@ -30,7 +30,7 @@ define(['jQuery'
       @set 'query', $searchField.val()
       @fetch success: () =>
         # Tracking
-        mixpanel.track 'Search', Shark.config.tempAdd({
+        mixpanel.track 'Search', Shark.config.asObject({
             query: @.get('query')
           , courseResultsCount: @.get('courses').length
           , queryTime: @.get('time')

--- a/public/scripts/backbone-schedule/models/search-results.coffee
+++ b/public/scripts/backbone-schedule/models/search-results.coffee
@@ -29,6 +29,12 @@ define(['jQuery'
       @url = '/search?q='+$searchField.val()+'&t='+Shark.term.get('_id')
       @set 'query', $searchField.val()
       @fetch success: () =>
+        # Tracking
+        mixpanel.track 'Search', Shark.config.tempAdd({
+            query: @.get('query')
+          , courseResultsCount: @.get('courses').length
+          , queryTime: @.get('time')
+        })
         @cleanResultsWithSchedule()
 
         # Anouce that the searchis complete

--- a/public/scripts/backbone-schedule/models/settings.coffee
+++ b/public/scripts/backbone-schedule/models/settings.coffee
@@ -1,0 +1,20 @@
+define(['jQuery'
+        'Underscore'
+        'Backbone'
+        'models/model'], ($, _, Backbone, SharkModel) ->
+
+  class UserSettings extends SharkModel
+
+    urlRoot: '/api/settings'
+
+    initialize: ->
+      _.bindAll @
+
+    tempAdd: (options={}) ->
+      result = options
+      for key,val of @.attributes
+        result[key] = val
+      result
+
+  UserSettings
+)

--- a/public/scripts/backbone-schedule/models/settings.coffee
+++ b/public/scripts/backbone-schedule/models/settings.coffee
@@ -10,7 +10,8 @@ define(['jQuery'
     initialize: ->
       _.bindAll @
 
-    tempAdd: (options={}) ->
+    asObject: (options={}) ->
+      # Return this object's parameters with options added in
       result = options
       for key,val of @.attributes
         result[key] = val

--- a/public/scripts/backbone-schedule/router.coffee
+++ b/public/scripts/backbone-schedule/router.coffee
@@ -64,16 +64,21 @@ define(['jQuery'
 
     requireSchool: (next=(()->return))->
       if !Shark.school.id
+        mixpanel.track 'Shown School Picker', Shark.config.tempAdd()
         @picker = new SchoolPickerView {next: next}
       else
         next()
 
     home: () ->
+      # Tracking
       mixpanel.track_pageview Backbone.history.getFragment()
+
       Shark.appView.show('home')
 
     scheduler: () ->
+      # Trakcing
       mixpanel.track_pageview Backbone.history.getFragment()
+
       @requireSchool ()=>
         Shark.appView.show('scheduler')
         if Shark.schedule.get('sections').length > 0
@@ -82,12 +87,13 @@ define(['jQuery'
           Shark.view.panelsView.hideMaxCal()
 
     settings: () ->
-      Shark.appView.show('settings')
+      # Tracking
       mixpanel.track_pageview Backbone.history.getFragment()
+
+      Shark.appView.show('settings')
 
     view: (id) ->
       @requireSchool ()=>
-        mixpanel.track_pageview Backbone.history.getFragment()
         Shark.appView.show('scheduler')
         if id
           Shark.schedule.ensureScheduleLoaded id,
@@ -97,14 +103,18 @@ define(['jQuery'
               Shark.router.navigate '', trigger: true, replace: true
 
     login: ->
-      mixpanel.track 'login_dialog'
+      # Tracking
+      mixpanel.track 'Login Dialog', Shark.config.attributes
+
       if !Shark.session.authenticated()
         Shark.session.login()
       else
         @navigate '', trigger: false, replace: true
 
     loadSchedule: (id) ->
-      mixpanel.track 'load'
+      # Tracking
+      mixpanel.track 'Load Schedule', Shark.config.attributes
+
       Shark.appView.show('scheduler')
       Shark.schedule.ensureScheduleLoaded id,
       success: ()=>
@@ -114,8 +124,10 @@ define(['jQuery'
         @navigate '', trigger: true, replace: true
 
     showLink: (link) ->
+      # Tracking
       mixpanel.track_pageview Backbone.history.getFragment()
-      mixpanel.track 'view_link', {link: link}
+      mixpanel.track 'View Link', Shark.config.tempAdd link: link
+
       Shark.appView.show('scheduler')
       Shark.shareLink = new ShareLink hash: link
       Shark.shareLink.fetch

--- a/public/scripts/backbone-schedule/router.coffee
+++ b/public/scripts/backbone-schedule/router.coffee
@@ -69,9 +69,11 @@ define(['jQuery'
         next()
 
     home: () ->
+      mixpanel.track_pageview Backbone.history.getFragment()
       Shark.appView.show('home')
 
     scheduler: () ->
+      mixpanel.track_pageview Backbone.history.getFragment()
       @requireSchool ()=>
         Shark.appView.show('scheduler')
         if Shark.schedule.get('sections').length > 0
@@ -81,9 +83,11 @@ define(['jQuery'
 
     settings: () ->
       Shark.appView.show('settings')
+      mixpanel.track_pageview Backbone.history.getFragment()
 
     view: (id) ->
       @requireSchool ()=>
+        mixpanel.track_pageview Backbone.history.getFragment()
         Shark.appView.show('scheduler')
         if id
           Shark.schedule.ensureScheduleLoaded id,
@@ -93,12 +97,14 @@ define(['jQuery'
               Shark.router.navigate '', trigger: true, replace: true
 
     login: ->
+      mixpanel.track 'login_dialog'
       if !Shark.session.authenticated()
         Shark.session.login()
       else
         @navigate '', trigger: false, replace: true
 
     loadSchedule: (id) ->
+      mixpanel.track 'load'
       Shark.appView.show('scheduler')
       Shark.schedule.ensureScheduleLoaded id,
       success: ()=>
@@ -108,6 +114,8 @@ define(['jQuery'
         @navigate '', trigger: true, replace: true
 
     showLink: (link) ->
+      mixpanel.track_pageview Backbone.history.getFragment()
+      mixpanel.track 'view_link', {link: link}
       Shark.appView.show('scheduler')
       Shark.shareLink = new ShareLink hash: link
       Shark.shareLink.fetch

--- a/public/scripts/backbone-schedule/router.coffee
+++ b/public/scripts/backbone-schedule/router.coffee
@@ -64,7 +64,7 @@ define(['jQuery'
 
     requireSchool: (next=(()->return))->
       if !Shark.school.id
-        mixpanel.track 'Shown School Picker', Shark.config.tempAdd()
+        mixpanel.track 'Shown School Picker', Shark.config.asObject()
         @picker = new SchoolPickerView {next: next}
       else
         next()
@@ -126,7 +126,7 @@ define(['jQuery'
     showLink: (link) ->
       # Tracking
       mixpanel.track_pageview Backbone.history.getFragment()
-      mixpanel.track 'View Link', Shark.config.tempAdd link: link
+      mixpanel.track 'View Link', Shark.config.asObject link: link
 
       Shark.appView.show('scheduler')
       Shark.shareLink = new ShareLink hash: link

--- a/public/scripts/backbone-schedule/views/main-nav.coffee
+++ b/public/scripts/backbone-schedule/views/main-nav.coffee
@@ -76,15 +76,18 @@ define(['jQuery'
     showUserMenu: (e) ->
       Shark.dropdown?.hide()
       Shark.dropdown = new AccountDropdownView()
+      mixpanel.track 'Show User Menu', Shark.config.tempAdd({from: 'Nav'})
       e.stopPropagation()
 
     showNotifications: (e) ->
       Shark.dropdown?.hide()
       Shark.dropdown = new NotificationsDropdownView()
+      mixpanel.track 'Check Notifications', Shark.config.tempAdd({from: 'Nav'})
       e.stopPropagation()
 
     showScheduler: (e) ->
       Shark.router.navigate '', trigger: true
+      mixpanel.track 'Show Scheduler', Shark.config.tempAdd({from: 'Nav'})
 
     updateFriendNotifications: ->
       return if not Shark.session.authenticated()

--- a/public/scripts/backbone-schedule/views/main-nav.coffee
+++ b/public/scripts/backbone-schedule/views/main-nav.coffee
@@ -76,18 +76,18 @@ define(['jQuery'
     showUserMenu: (e) ->
       Shark.dropdown?.hide()
       Shark.dropdown = new AccountDropdownView()
-      mixpanel.track 'Show User Menu', Shark.config.tempAdd({from: 'Nav'})
+      mixpanel.track 'Show User Menu', Shark.config.asObject({from: 'Nav'})
       e.stopPropagation()
 
     showNotifications: (e) ->
       Shark.dropdown?.hide()
       Shark.dropdown = new NotificationsDropdownView()
-      mixpanel.track 'Check Notifications', Shark.config.tempAdd({from: 'Nav'})
+      mixpanel.track 'Check Notifications', Shark.config.asObject({from: 'Nav'})
       e.stopPropagation()
 
     showScheduler: (e) ->
       Shark.router.navigate '', trigger: true
-      mixpanel.track 'Show Scheduler', Shark.config.tempAdd({from: 'Nav'})
+      mixpanel.track 'Show Scheduler', Shark.config.asObject({from: 'Nav'})
 
     updateFriendNotifications: ->
       return if not Shark.session.authenticated()

--- a/public/scripts/backbone-schedule/views/modals/load.coffee
+++ b/public/scripts/backbone-schedule/views/modals/load.coffee
@@ -22,7 +22,7 @@ define(['jQuery'
       @.hide()
 
     show: ->
-      mixpanel.track 'Load Dialog Open', Shark.config.tempAdd()
+      mixpanel.track 'Load Dialog Open', Shark.config.asObject()
       @$el.html(@loadTemplate()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>

--- a/public/scripts/backbone-schedule/views/modals/load.coffee
+++ b/public/scripts/backbone-schedule/views/modals/load.coffee
@@ -18,9 +18,11 @@ define(['jQuery'
     load: ->
       toLoad = Shark.schedulesList.get(@list.val())
       Shark.router.navigate toLoad.id, trigger: true, replace: false
+      # Tracked in router
       @.hide()
 
     show: ->
+      mixpanel.track 'Load Dialog Open', Shark.config.tempAdd()
       @$el.html(@loadTemplate()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>

--- a/public/scripts/backbone-schedule/views/modals/new.coffee
+++ b/public/scripts/backbone-schedule/views/modals/new.coffee
@@ -17,6 +17,7 @@ define(['jQuery'
       'click #do-new' : 'new'
 
     show: ->
+      mixpanel.track 'New Dialog Open', Shark.config.tempAdd()
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>
@@ -33,6 +34,9 @@ define(['jQuery'
       @$el.modal 'hide'
 
     new: ->
+      # Tracking
+      mixpanel.track 'New Schedule', Shark.config.tempAdd({term: @$options.val()})
+
       # Close the modal
       @hide()
 

--- a/public/scripts/backbone-schedule/views/modals/new.coffee
+++ b/public/scripts/backbone-schedule/views/modals/new.coffee
@@ -17,7 +17,7 @@ define(['jQuery'
       'click #do-new' : 'new'
 
     show: ->
-      mixpanel.track 'New Dialog Open', Shark.config.tempAdd()
+      mixpanel.track 'New Dialog Open', Shark.config.asObject()
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>
@@ -35,7 +35,7 @@ define(['jQuery'
 
     new: ->
       # Tracking
-      mixpanel.track 'New Schedule', Shark.config.tempAdd({term: @$options.val()})
+      mixpanel.track 'New Schedule', Shark.config.asObject({term: @$options.val()})
 
       # Close the modal
       @hide()

--- a/public/scripts/backbone-schedule/views/modals/register.coffee
+++ b/public/scripts/backbone-schedule/views/modals/register.coffee
@@ -13,6 +13,7 @@ define(['jQuery'
       @template = _.template templateText
 
     show: ->
+      mixpanel.track 'CRN Dialog Show', Shark.config.tempAdd({count: Shark.schedule.get('sections').length})
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>

--- a/public/scripts/backbone-schedule/views/modals/register.coffee
+++ b/public/scripts/backbone-schedule/views/modals/register.coffee
@@ -13,7 +13,7 @@ define(['jQuery'
       @template = _.template templateText
 
     show: ->
-      mixpanel.track 'CRN Dialog Show', Shark.config.tempAdd({count: Shark.schedule.get('sections').length})
+      mixpanel.track 'CRN Dialog Show', Shark.config.asObject({count: Shark.schedule.get('sections').length})
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>

--- a/public/scripts/backbone-schedule/views/modals/save.coffee
+++ b/public/scripts/backbone-schedule/views/modals/save.coffee
@@ -17,16 +17,22 @@ define(['jQuery'
 
     save: ->
 
+
       # Instant feedback by hiding modal
       @hide()
 
       name = @$name.val()
+
+      # Tracking
+      mixpanel.track 'Save Schedule', Shark.config.tempAdd({name: name})
+
       Shark.schedule.unset '_id' if name != Shark.schedule.get 'name'
       Shark.schedule.set 'name', name
       Shark.schedule.set 'term', Shark.term
       Shark.schedule.save()
 
     show: ->
+      mixpanel.track 'Save Dialog Show', Shark.config.tempAdd()
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>

--- a/public/scripts/backbone-schedule/views/modals/save.coffee
+++ b/public/scripts/backbone-schedule/views/modals/save.coffee
@@ -24,7 +24,7 @@ define(['jQuery'
       name = @$name.val()
 
       # Tracking
-      mixpanel.track 'Save Schedule', Shark.config.tempAdd({name: name})
+      mixpanel.track 'Save Schedule', Shark.config.asObject({name: name})
 
       Shark.schedule.unset '_id' if name != Shark.schedule.get 'name'
       Shark.schedule.set 'name', name
@@ -32,7 +32,7 @@ define(['jQuery'
       Shark.schedule.save()
 
     show: ->
-      mixpanel.track 'Save Dialog Show', Shark.config.tempAdd()
+      mixpanel.track 'Save Dialog Show', Shark.config.asObject()
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>

--- a/public/scripts/backbone-schedule/views/modals/school-picker/option.coffee
+++ b/public/scripts/backbone-schedule/views/modals/school-picker/option.coffee
@@ -21,6 +21,10 @@ define(['jQuery'
       @$el.html @template school: @model
 
     choose: ->
+
+      # Tracing
+      mixpanel.track 'Picked School', Shark.config.tempAdd({name: @model.get('name')})
+
       Shark.setSchool @model, ()=>
         @next()
 

--- a/public/scripts/backbone-schedule/views/modals/school-picker/option.coffee
+++ b/public/scripts/backbone-schedule/views/modals/school-picker/option.coffee
@@ -23,7 +23,7 @@ define(['jQuery'
     choose: ->
 
       # Tracing
-      mixpanel.track 'Picked School', Shark.config.tempAdd({name: @model.get('name')})
+      mixpanel.track 'Picked School', Shark.config.asObject({name: @model.get('name')})
 
       Shark.setSchool @model, ()=>
         @next()

--- a/public/scripts/backbone-schedule/views/modals/share.coffee
+++ b/public/scripts/backbone-schedule/views/modals/share.coffee
@@ -18,7 +18,7 @@ define(['jQuery'
 
     show: ->
       # Tracing
-      mixpanel.track 'Schedule Link', Shark.config.tempAdd()
+      mixpanel.track 'Schedule Link', Shark.config.asObject()
 
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()

--- a/public/scripts/backbone-schedule/views/modals/share.coffee
+++ b/public/scripts/backbone-schedule/views/modals/share.coffee
@@ -17,6 +17,9 @@ define(['jQuery'
       @render()
 
     show: ->
+      # Tracing
+      mixpanel.track 'Schedule Link', Shark.config.tempAdd()
+
       @$el.html(@template()).appendTo $ 'body'
       @delegateEvents()
       @$el.on 'hidden', =>

--- a/public/scripts/backbone-schedule/views/scheduler/friend.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friend.coffee
@@ -41,11 +41,11 @@ define(['jQuery'
       if @$el.hasClass 'chosen'
         @$el.css border: '3px solid '+@model.color()
         Shark.friendsList.trigger('showFriendsSchedule', @model)
-        mixpanel.track 'View Friend Schedule', Shark.config.tempAdd()
+        mixpanel.track 'View Friend Schedule', Shark.config.asObject()
       else
         @$el.css border: 'none'
         Shark.friendsList.trigger('hideFriendsSchedule', @model)
-        mixpanel.track 'Hide Friend Schedule', Shark.config.tempAdd()
+        mixpanel.track 'Hide Friend Schedule', Shark.config.asObject()
 
     teardown: ->
       super()

--- a/public/scripts/backbone-schedule/views/scheduler/friend.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friend.coffee
@@ -41,9 +41,11 @@ define(['jQuery'
       if @$el.hasClass 'chosen'
         @$el.css border: '3px solid '+@model.color()
         Shark.friendsList.trigger('showFriendsSchedule', @model)
+        mixpanel.track 'View Friend Schedule', Shark.config.tempAdd()
       else
         @$el.css border: 'none'
         Shark.friendsList.trigger('hideFriendsSchedule', @model)
+        mixpanel.track 'Hide Friend Schedule', Shark.config.tempAdd()
 
     teardown: ->
       super()

--- a/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
@@ -27,7 +27,9 @@ define(['jQuery'
 
     addFriends: ->
       @hide()
-      @$el.find('.friend-option.chosen').each (index, friendChosen) ->
+      $chosen = @$el.find('.friend-option.chosen')
+      mixpanel.track 'Add Friends', Shark.config.tempAdd({count: $chosen.length })
+      $chosen.each (index, friendChosen) ->
         Shark.friendsList.add(
           new Friend
             _id: $(friendChosen).data('user-id')

--- a/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
@@ -56,5 +56,8 @@ define(['jQuery'
       @$el.on 'hidden', () ->
         @teardown()
 
+    teardown: ->
+      super()
+
   FriendsFromFacebookView
 )

--- a/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
@@ -28,7 +28,7 @@ define(['jQuery'
     addFriends: ->
       @hide()
       $chosen = @$el.find('.friend-option.chosen')
-      mixpanel.track 'Add Friends', Shark.config.tempAdd({count: $chosen.length })
+      mixpanel.track 'Add Friends', Shark.config.asObject({count: $chosen.length })
       $chosen.each (index, friendChosen) ->
         Shark.friendsList.add(
           new Friend

--- a/public/scripts/backbone-schedule/views/scheduler/friends-list.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friends-list.coffee
@@ -50,6 +50,7 @@ define(['jQuery'
 
     addFriends: ->
       console.log 'Adding friends. [NOT IMPLEMENTED]'
+      mixpanel.track 'Find Friends', Shark.config.tempAdd({through: "CourseShark"})
 
     findAndAddFriends: ->
       # Would actually open a dialog to find friends with
@@ -60,6 +61,7 @@ define(['jQuery'
         $.ajax url: '/friends/find-from-facebook', success: (d) =>
           if not d.error
             friends = d
+            mixpanel.track 'Find Friends', Shark.config.tempAdd({through: "Facebook"})
             @friendPicker = new FriendsFromFacebookView(model: new FacebookFriendsResults(friends))
             @friendPicker.show()
           else if d.error is "No Facebook token exists for user"

--- a/public/scripts/backbone-schedule/views/scheduler/friends-list.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friends-list.coffee
@@ -50,7 +50,7 @@ define(['jQuery'
 
     addFriends: ->
       console.log 'Adding friends. [NOT IMPLEMENTED]'
-      mixpanel.track 'Find Friends', Shark.config.tempAdd({through: "CourseShark"})
+      mixpanel.track 'Find Friends', Shark.config.asObject({through: "CourseShark"})
 
     findAndAddFriends: ->
       # Would actually open a dialog to find friends with
@@ -61,7 +61,7 @@ define(['jQuery'
         $.ajax url: '/friends/find-from-facebook', success: (d) =>
           if not d.error
             friends = d
-            mixpanel.track 'Find Friends', Shark.config.tempAdd({through: "Facebook"})
+            mixpanel.track 'Find Friends', Shark.config.asObject({through: "Facebook"})
             @friendPicker = new FriendsFromFacebookView(model: new FacebookFriendsResults(friends))
             @friendPicker.show()
           else if d.error is "No Facebook token exists for user"

--- a/public/scripts/backbone-schedule/views/scheduler/nav.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/nav.coffee
@@ -44,12 +44,16 @@ define(['jQuery'
       @newView.show()
 
     print: ->
+      mixpanel.track 'Print Schedule', Shark.config.tempAdd()
       window.print()
 
     link: ->
       @shareView.show()
 
     ical: ->
+      # Tracing
+      mixpanel.track 'Export Schedule', Shark.config.tempAdd()
+
       $('#ical-button').attr('href', Shark.schedule.export()).attr('download', Shark.schedule.get('name'));
 
     register: ->

--- a/public/scripts/backbone-schedule/views/scheduler/nav.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/nav.coffee
@@ -44,7 +44,7 @@ define(['jQuery'
       @newView.show()
 
     print: ->
-      mixpanel.track 'Print Schedule', Shark.config.tempAdd()
+      mixpanel.track 'Print Schedule', Shark.config.asObject()
       window.print()
 
     link: ->
@@ -52,7 +52,7 @@ define(['jQuery'
 
     ical: ->
       # Tracing
-      mixpanel.track 'Export Schedule', Shark.config.tempAdd()
+      mixpanel.track 'Export Schedule', Shark.config.asObject()
 
       $('#ical-button').attr('href', Shark.schedule.export()).attr('download', Shark.schedule.get('name'));
 

--- a/views/schedule/schedule.ejs
+++ b/views/schedule/schedule.ejs
@@ -1,8 +1,6 @@
 <div id="app-container"></div>
 <div id="fb-root"></div>
-
-
-<script defer="defer">
+<script>
 	window.requestAnimFrame = (function(){
 		return  window.requestAnimationFrame ||
 		  window.webkitRequestAnimationFrame ||
@@ -20,6 +18,7 @@
 		, baseDir: "/s/"
     , domain: "<%=domain%>"
 		, facebook: { appId: "<%= app.config.facebook.appId %>" }
+    , distinctId: "<%= distinctId %>"
     <%if (loggedIn){ %>
     , auth: {
           user: <%-JSON.stringify(user)%>
@@ -29,12 +28,32 @@
     <%}%>
 	}
 </script>
+
+<!-- Mixpanel -->
+<script type="text/javascript">
+(function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
+b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
+'//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';d=c.getElementsByTagName("script")[0];
+d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
+var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
+Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
+f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
+'track_forms','register','register_once','unregister','identify','alias','name_tag',
+'set_config','people.set','people.increment'];for(e=0;e<h.length;e++)d(g,h[e]);
+a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
+mixpanel.init("22566cab7f699ae4100bd3d23dfc1420", {track_pageview: false<%if (mode!="production"){%>, debug: true, test: true<%}%>});
+mixpanel.register({ distinct_id: CS.distinctId });
+// error logger
+window.onerror=function(m,f,l){mixpanel.track('js-err',{message:m,file:f,line:l})}
+</script>
+<!-- end Mixpanel -->
+
+
 <%if ( built ){ %>
 <script src="/scripts/backbone-schedule/build.main.js" defer="defer"></script>
 <%}else{%>
 <script data-main="/scripts/backbone-schedule/main" src="/scripts/backbone-schedule/lib/require/require.js"></script>
 <%}%>
-
 <!-- Facebook -->
 <script>
   window.fbAsyncInit = function() {

--- a/views/schedule/schedule.ejs
+++ b/views/schedule/schedule.ejs
@@ -19,6 +19,7 @@
     , domain: "<%=domain%>"
 		, facebook: { appId: "<%= app.config.facebook.appId %>" }
     , distinctId: "<%= distinctId %>"
+    , settings: <%-JSON.stringify(settings)%>
     <%if (loggedIn){ %>
     , auth: {
           user: <%-JSON.stringify(user)%>


### PR DESCRIPTION
## Mixpanel Integration
- `mixpanel` object is now available on the page
- Standard events are tracked
- `Shark.config` is the flip-flop evaluated settings object
  - `Shark.config` is updated on [un-]auth events
- `Shark.config.asObject()` expands and returns the `Shark.config` object's properties
- Mixpanel events sent with Shark.config options as parameters 
