### PR TITLE
Styling updates

### DIFF
--- a/controllers/site.js
+++ b/controllers/site.js
@@ -6,9 +6,9 @@ exports = module.exports = function(app){
   app.get('/', function(req, res){
     if ( require('../lib/flipflop').test('canSeeNewScheduler', req) ){
       res.redirect('/s/home');
-      return;
+    }else{
+      res.render('index');
     }
-    res.render('index', {});
   })
 
   // About pages

--- a/public/scripts/backbone-schedule/app.coffee
+++ b/public/scripts/backbone-schedule/app.coffee
@@ -71,6 +71,9 @@ define(['jQuery'
       @.terms = new Terms
       @.schedulesList = new Schedules
       @.schedule = new Schedule
+      @.schedule.on 'change:name', (schedule) ->
+        name = schedule.get('name') or Shark.term?.get('name') or 'New Schedule'
+        document.title = "#{name} | CourseShark"
 
 
       # Set the school if it has been passed down

--- a/public/scripts/backbone-schedule/app.coffee
+++ b/public/scripts/backbone-schedule/app.coffee
@@ -24,8 +24,8 @@ define(['jQuery'
 
       # User settings setup and listeners
       @.config = new UserSettings(CS.settings)
-      @configBasedSetup()
       @.config.on 'change', @configBasedSetup
+      @configBasedSetup()
 
 
       # Setup the session
@@ -53,6 +53,7 @@ define(['jQuery'
             mixpanel.track 'authenticated', @.config.asObject()
       @.session.on 'unauthenticated', () =>
         @.friendsList.reset()
+        @.friendInvites.reset()
         @.friendsList.trigger('unfetched')
         @.config.fetch()
         mixpanel.track 'unauthenticated', @.config.asObject()
@@ -96,7 +97,7 @@ define(['jQuery'
           @.schedule.set 'term', @.term
           next()
 
-    configBasedSetup: ->
+    configBasedSetup: =>
       if @.config.can('useWebsockets') and not @.sockets
         @.sockets =
           seats: io.connect('/seats')

--- a/public/scripts/backbone-schedule/models/schedule.coffee
+++ b/public/scripts/backbone-schedule/models/schedule.coffee
@@ -29,11 +29,12 @@ define(['jQuery'
           res[prop] = _.clone(@attributes[prop])
       return res;
 
-    new: ->
+    new: (term) ->
       @.unset '__v'
       @.unset '_id'
       @.set 'name', ''
       @.get('sections').reset()
+      @.set 'term', term or Shark.term
 
     load: (success) ->
       @.fetch

--- a/public/scripts/backbone-schedule/models/search-results.coffee
+++ b/public/scripts/backbone-schedule/models/search-results.coffee
@@ -55,6 +55,7 @@ define(['jQuery'
           # If it exists in the schedule object, replace it with the schedule's version
           if Shark.schedule.contains(section)
             course.attributes.sections.models[i] = Shark.schedule.get('sections').get(section.get('_id'))
+      return if not @get('sections')
       @get('sections').each (section) ->
         if Shark.schedule.contains(section)
           section = Shark.schedule.get('sections').get(section.id)

--- a/public/scripts/backbone-schedule/views/auth/forgot-password.coffee
+++ b/public/scripts/backbone-schedule/views/auth/forgot-password.coffee
@@ -8,7 +8,7 @@ define(['jQuery',
 
     tagName: "div"
 
-    className: "modal fade"
+    className: "modal"
 
     events:
       "keypress .forgot-form-input-email": "checkSubmit"

--- a/public/scripts/backbone-schedule/views/auth/login.coffee
+++ b/public/scripts/backbone-schedule/views/auth/login.coffee
@@ -8,7 +8,7 @@ define(['jQuery',
 
     tagName: "div"
 
-    className: "modal fade"
+    className: "modal"
 
     events:
       "keypress .login-form-input-password": "checkSubmit"

--- a/public/scripts/backbone-schedule/views/auth/resolve-duplicate.coffee
+++ b/public/scripts/backbone-schedule/views/auth/resolve-duplicate.coffee
@@ -6,7 +6,7 @@ define(['jQuery'
 
   class ResolveDuplicateView extends SharkView
 
-    className: "modal hide fade"
+    className: "modal hide"
 
     initialize: ->
       _.bindAll @

--- a/public/scripts/backbone-schedule/views/auth/signup.coffee
+++ b/public/scripts/backbone-schedule/views/auth/signup.coffee
@@ -8,7 +8,7 @@ define(['jQuery'
 
 		tagName: "div"
 
-		className: "modal fade"
+		className: "modal"
 
 		events:
 			"keypress .signup-form-input-password": "checkSubmit"

--- a/public/scripts/backbone-schedule/views/dropdowns/notifications.coffee
+++ b/public/scripts/backbone-schedule/views/dropdowns/notifications.coffee
@@ -17,6 +17,7 @@ define(['jQuery'
         @$el = $('#dropdown-view')
 
       Shark.friendInvites.on 'add', @render
+      Shark.friendInvites.on 'reset', @render
       Shark.friendInvites.on 'remove', @render
 
       @inviteViews = []
@@ -26,9 +27,9 @@ define(['jQuery'
 
     render: ->
       @$el.hide().css(right: '160px').html @template()
-      $list = @$el.find('.request-list')
+      $list = @$el.find('.request-list').empty()
       for view in @inviteViews
-        view.teardown()
+        view.teardown?()
       @inviteViews = []
       finishRender = =>
         @$el

--- a/public/scripts/backbone-schedule/views/modals/load.coffee
+++ b/public/scripts/backbone-schedule/views/modals/load.coffee
@@ -6,7 +6,7 @@ define(['jQuery'
 
   class LoadView extends SharkView
 
-    className: "modal hide fade"
+    className: "modal hide"
 
     initialize: ->
       _.bindAll @

--- a/public/scripts/backbone-schedule/views/modals/new.coffee
+++ b/public/scripts/backbone-schedule/views/modals/new.coffee
@@ -7,7 +7,7 @@ define(['jQuery'
 
   class NewView extends SharkView
 
-    className: "modal hide fade"
+    className: "modal hide"
 
     initialize: ->
       _.bindAll @

--- a/public/scripts/backbone-schedule/views/modals/new.coffee
+++ b/public/scripts/backbone-schedule/views/modals/new.coffee
@@ -42,11 +42,11 @@ define(['jQuery'
 
       Shark.router.navigate '', trigger: false, replace: true
 
-      # Tell the schedule object to essentially reset itself
-      Shark.schedule.new()
-
       # Select the term chosen, defaulting to the current Term if none checked
       Shark.term = Shark.terms.where( _id: @$options.val() )[0] or Shark.school.get 'currentTerm'
+
+      # Tell the schedule object to essentially reset itself
+      Shark.schedule.new Shark.term
 
 
   NewView

--- a/public/scripts/backbone-schedule/views/modals/register.coffee
+++ b/public/scripts/backbone-schedule/views/modals/register.coffee
@@ -6,7 +6,7 @@ define(['jQuery'
 
   class RegisterView extends SharkView
 
-    className: "modal hide fade"
+    className: "modal hide"
 
     initialize: ->
       _.bindAll @

--- a/public/scripts/backbone-schedule/views/modals/save.coffee
+++ b/public/scripts/backbone-schedule/views/modals/save.coffee
@@ -28,7 +28,7 @@ define(['jQuery'
 
       Shark.schedule.unset '_id' if name != Shark.schedule.get 'name'
       Shark.schedule.set 'name', name
-      Shark.schedule.set 'term', Shark.term
+      Shark.schedule.set 'term', Shark.term if not Shark.schedule.get 'term'
       Shark.schedule.save()
 
     show: ->

--- a/public/scripts/backbone-schedule/views/modals/save.coffee
+++ b/public/scripts/backbone-schedule/views/modals/save.coffee
@@ -6,7 +6,7 @@ define(['jQuery'
 
   class SaveView extends SharkView
 
-    className: "modal hide fade"
+    className: "modal hide"
 
     initialize: ->
       _.bindAll @

--- a/public/scripts/backbone-schedule/views/modals/school-picker.coffee
+++ b/public/scripts/backbone-schedule/views/modals/school-picker.coffee
@@ -10,7 +10,7 @@ define(['jQuery'
   class SchoolPickerView extends SharkView
 
 
-    className: "modal hide fade"
+    className: "modal hide"
 
     initialize: (options)->
       _.bindAll @

--- a/public/scripts/backbone-schedule/views/modals/share.coffee
+++ b/public/scripts/backbone-schedule/views/modals/share.coffee
@@ -7,7 +7,7 @@ define(['jQuery'
 
   class ShareView extends SharkView
 
-    className: "modal hide fade"
+    className: "modal hide"
 
     initialize: ->
       window._ = _

--- a/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/friends-from-facebook.coffee
@@ -9,7 +9,7 @@ define(['jQuery'
 
     tagName: "div"
 
-    className: "modal fade"
+    className: "modal"
 
     events:
       "click .close": "close"

--- a/public/scripts/backbone-schedule/views/scheduler/result-list.coffee
+++ b/public/scripts/backbone-schedule/views/scheduler/result-list.coffee
@@ -57,6 +57,7 @@ define(['jQuery'
           @subviews.push view
           @$courses.append view.render().el
 
+      return if not @searchResults.get 'sections'
       @searchResults.get('sections').each (section) =>
         if section.get('rank') >= 0.3
           view = new ResultsSectionView model: section

--- a/public/styles/schedule/modal.less
+++ b/public/styles/schedule/modal.less
@@ -1,5 +1,6 @@
 .modal-backdrop{
   background: @backdrop;
+  opacity: 0.5;
 }
 
 .modal{

--- a/public/styles/schedule/scheduler/framework.less
+++ b/public/styles/schedule/scheduler/framework.less
@@ -47,6 +47,7 @@ a{
 }
 
 .workspace-nav{
+	@media print{&{display: none;}}
 	.nav{
 		margin-bottom: 5px;
 	}

--- a/public/styles/schedule/scheduler/friends.less
+++ b/public/styles/schedule/scheduler/friends.less
@@ -70,8 +70,15 @@
 
 
 .friend-block{
-  width: 51px;
-  height: 51px;
+
+  width: 48px;
+  height: 48px;
+  @media (min-width: 1200px){
+    &{
+      width: 51px;
+      height: 51px;
+    }
+  }
   float: left;
   position: relative;
 

--- a/public/styles/schedule/scheduler/friends.less
+++ b/public/styles/schedule/scheduler/friends.less
@@ -1,4 +1,5 @@
 .friends-list{
+  @media print {&{ display: none;}}
   #add-friend{
     color: blue;
   }

--- a/public/styles/schedule/scheduler/results.less
+++ b/public/styles/schedule/scheduler/results.less
@@ -18,6 +18,7 @@
 }
 
 .results-course, .results-section{
+  overflow: visible;
   background-color: @white;
   .background-gradient-linear(@white, @light-grey);
   border-radius: 3px;
@@ -26,7 +27,6 @@
   box-shadow: 0px 0px 3px 0px #CCC;
   color: @text-grey;
   cursor: pointer;
-  overflow: hidden;
   padding: 3px 8px 3px 8px;
   margin: 5px;
   position: relative;
@@ -62,6 +62,9 @@
   }
 }
 
+.sections-list{
+  overflow: visible;
+}
 
 .results-section{
 

--- a/views/dialogs/login.ejs
+++ b/views/dialogs/login.ejs
@@ -10,7 +10,7 @@
 			<div class="control-group" id="login-email-control">
 				<label class="control-label" for="email">Email</label>
 	      <div class="controls">
-						<input type="email" name="email" id="email" tabindex="1" placeholder="Email Address" class="span6">
+						<input type="email" name="email" id="email" tabindex="1" placeholder="Email Address" class="span4">
 						<p class="help-inline" for="email"></p>
 				</div>
 			</div>
@@ -18,12 +18,9 @@
 			<div class="control-group" id="login-password-control">
 				<label class="control-label" for="password">Password</label>
 	      <div class="controls">
-					<input type="password" name="password" tabindex="2" id="password" <% if( !noJs ){%> onKeyUp="if(event.keyCode===13){login_submit();}"<%}%> placeholder="Password" class="span6">
-					<p class="help-inline"><a id="login-forgot-password"<% if( !noJs ){%> data-dismiss="modal" onClick="openDialog('/forgot-password');"<%}%>>Forgot?</a></p>
+					<input type="password" name="password" tabindex="2" id="password" onKeyUp="if(event.keyCode===13){login_submit();}" placeholder="Password" class="span4">
+					<p class="help-inline"><a id="login-forgot-password" data-dismiss="modal" onClick="openDialog('/forgot-password');">Forgot?</a></p>
 					<p class="help-inline" for="password"></p>
-				</div>
-				<div class="controls">
-					<label class="checkbox"><input type="checkbox" name="remember" id="remember" checked="checked" tabindex="3"> Keep me logged in</label>
 				</div>
 			</div>
 			<!-- Alt login -->
@@ -40,12 +37,12 @@
 		</fieldset>
 	</form>
 	<div class="bottom">
-		<p>Don't have an account? <a class="auth-register" <% if( !noJs ){%>data-dismiss="modal" onClick="openDialog('/signup');"<%}%>>Create one</a></p>
+		<p>Don't have an account? <a class="auth-register" data-dismiss="modal" onClick="openDialog('/signup');">Create one</a></p>
 	</div>
 </div>
 
 <div class="modal-footer">
-	<a href="#" class="btn btn-primary"<% if( !noJs ){%> onClick="login_submit()"<%}%>>Login</a>
+	<a href="#" class="btn btn-primary" onClick="login_submit()">Login</a>
 	<a href="#" class="btn" data-dismiss="modal">Close</a>
 </div>
 


### PR DESCRIPTION
## Print CSS
- Hides friends list
- Hides scheduler-nav
## Styling Updates
- Fixed issue #72  ( Login dialog reset for non-backbone )
- Fixed issue #99 ( Username tooltip )
## Terms
- Schedules on save are forced the schedule.term
- New schedules have their term's set to Shark.term or the term passed in 

``` coffeescript
    new: (term) ->
      ...
      @.set 'term', term or Shark.term
```
